### PR TITLE
Add proved type

### DIFF
--- a/Data/SBV/Plugin/Analyze.hs
+++ b/Data/SBV/Plugin/Analyze.hs
@@ -15,6 +15,7 @@
 module Data.SBV.Plugin.Analyze (analyzeBind) where
 
 import GhcPlugins
+import TyCoRep
 
 import Control.Monad.Reader
 import System.Exit
@@ -40,11 +41,18 @@ import Data.SBV.Plugin.Data
 -- | Dispatch the analyzer over bindings
 analyzeBind :: Config -> CoreBind -> CoreM ()
 analyzeBind cfg@Config{sbvAnnotation, cfgEnv} = go
-  where go (NonRec b e) = bind (b, e)
-        go (Rec binds)  = mapM_ bind binds
+  where go (NonRec b e) = condProve (b, e)
+        go (Rec binds)  = mapM_ condProve binds
 
-        bind (b, e) = mapM_ work (sbvAnnotation b)
-          where work (SBV opts)
+        condProve (b, e)
+          | not $ null (sbvAnnotation b)
+          = mapM_ workAnnotated (sbvAnnotation b)
+          | TyCoRep.TyConApp tc _ <- varType b
+          , (getOccString $ tyConName tc) == "Proved"
+          = liftIO $ prove cfg [] b e
+          | True
+          = return ()
+          where workAnnotated (SBV opts)
                    | Just s <- hasSkip opts
                    = liftIO $ putStrLn $ "[SBV] " ++ showSpan (flags cfgEnv) (pickSpan [varSpan b]) ++ " Skipping " ++ show (showSDoc (flags cfgEnv) (ppr b)) ++ ": " ++ s
                    | Uninterpret `elem` opts

--- a/Data/SBV/Plugin/Analyze.hs
+++ b/Data/SBV/Plugin/Analyze.hs
@@ -45,7 +45,7 @@ analyzeBind cfg@Config{sbvAnnotation, cfgEnv} = go
 
         bind (b, e) = mapM_ work (sbvAnnotation b)
           where work (SBV opts)
-                   | Just s <- hasSkip opts 
+                   | Just s <- hasSkip opts
                    = liftIO $ putStrLn $ "[SBV] " ++ showSpan (flags cfgEnv) (pickSpan [varSpan b]) ++ " Skipping " ++ show (showSDoc (flags cfgEnv) (ppr b)) ++ ": " ++ s
                    | Uninterpret `elem` opts
                    = return ()
@@ -58,7 +58,7 @@ prove :: Config -> [SBVOption] -> Var -> CoreExpr -> IO ()
 prove cfg@Config{isGHCi} opts b e = do
         success <- safely $ proveIt cfg opts b e
         unless (success || isGHCi || IgnoreFailure `elem` opts) $ do
-            putStrLn $ "[SBV] Failed. (Use option '" ++ show IgnoreFailure ++ "' to continue.)" 
+            putStrLn $ "[SBV] Failed. (Use option '" ++ show IgnoreFailure ++ "' to continue.)"
             exitFailure
 
 -- | Safely execute an action, catching the exceptions, printing and returning False if something goes wrong

--- a/Data/SBV/Plugin/Data.hs
+++ b/Data/SBV/Plugin/Data.hs
@@ -47,3 +47,6 @@ sbv = SBV {options = []}
 -- | Synonym for sbv really, just looks cooler
 theorem :: SBVAnnotation
 theorem = sbv
+
+-- | Importable type as an annotation alternative
+type Proved a = a

--- a/Data/SBV/Plugin/Examples/Proved.hs
+++ b/Data/SBV/Plugin/Examples/Proved.hs
@@ -1,0 +1,26 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.Plugin.Examples.Proved
+-- Copyright   :  (c) Nickolas Fotopoulos
+-- License     :  BSD3
+-- Maintainer  :  nickolas.fotopoulos@gmail.com
+-- Stability   :  experimental
+--
+-- An example of activating sbvPlugin by wrapping types in Proved
+-- instead of using an annotation.
+--
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -fplugin=Data.SBV.Plugin #-}
+
+module Data.SBV.Plugin.Examples.Proved where
+
+import Data.SBV.Plugin.Data
+
+-- A top-level binding with its type wrapped in Proved causes sbvPlugin to
+-- run a proof on the expression.
+integerAssociative :: Proved (Integer -> Integer -> Integer -> Bool)
+integerAssociative x y z = ((x + y) + z) == (x + (y + z))
+
+isTrue :: Proved Bool
+isTrue = True || False

--- a/sbvPlugin.cabal
+++ b/sbvPlugin.cabal
@@ -26,12 +26,13 @@ Library
   default-language: Haskell2010
   ghc-options     : -Wall -fplugin-opt Data.SBV.Plugin:skip
   Exposed-modules : Data.SBV.Plugin
+                  , Data.SBV.Plugin.Data
                   , Data.SBV.Plugin.Examples.MergeSort
                   , Data.SBV.Plugin.Examples.MicroController
                   , Data.SBV.Plugin.Examples.BitTricks
+                  , Data.SBV.Plugin.Examples.Proved
   build-depends   : base >= 4.9 && < 5, ghc, ghc-prim, containers, sbv >= 5.12, mtl, template-haskell
   Other-modules   : Data.SBV.Plugin.Analyze
-                  , Data.SBV.Plugin.Data
                   , Data.SBV.Plugin.Common
                   , Data.SBV.Plugin.Env
                   , Data.SBV.Plugin.Plugin

--- a/tests/GoldFiles/T50.hs.golden
+++ b/tests/GoldFiles/T50.hs.golden
@@ -1,0 +1,6 @@
+
+[SBV] tests/T50.hs:23:1-18 Proving "integerAssociative", using Z3.
+[Z3] Q.E.D.
+
+[SBV] tests/T50.hs:26:1-6 Proving "isTrue", using Z3.
+[Z3] Q.E.D.

--- a/tests/T50.hs
+++ b/tests/T50.hs
@@ -1,0 +1,26 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.SBV.Plugin.Examples.Proved
+-- Copyright   :  (c) Nickolas Fotopoulos
+-- License     :  BSD3
+-- Maintainer  :  nickolas.fotopoulos@gmail.com
+-- Stability   :  experimental
+--
+-- An example of activating sbvPlugin by wrapping types in Proved
+-- instead of using an annotation.
+--
+-----------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -fplugin=Data.SBV.Plugin #-}
+
+module Data.SBV.Plugin.Examples.Proved where
+
+import Data.SBV.Plugin.Data
+
+-- A top-level binding with its type wrapped in Proved causes sbvPlugin to
+-- run a proof on the expression.
+integerAssociative :: Proved (Integer -> Integer -> Integer -> Bool)
+integerAssociative x y z = ((x + y) + z) == (x + (y + z))
+
+isTrue :: Proved Bool
+isTrue = True || False


### PR DESCRIPTION
This pull request adds a new type Proved, which, when you call its constructor on a function you have written, will cause sbvPlugin to prove that function without the use of an annotation. Bindings and types are first-class citizens in Haskell in a way that annotations are not. This pull request may not do much by itself, but improves ergonomics and paves the way toward future uses of sbvPlugin.