### PR TITLE
Update for sbv 8.9

### DIFF
--- a/Data/SBV/Plugin/Common.hs
+++ b/Data/SBV/Plugin/Common.hs
@@ -91,7 +91,7 @@ data Config = Config { isGHCi        :: Bool
 -- | Given the user options, determine which solver(s) to use
 pickSolvers :: [SBVOption] -> IO [S.SMTConfig]
 pickSolvers slvrs
-  | AnySolver `elem` slvrs = S.sbvAvailableSolvers
+  | AnySolver `elem` slvrs = S.getAvailableSolvers
   | True                   = case mapMaybe (`lookup` solvers) slvrs of
                                 [] -> return [S.defaultSMTCfg]
                                 xs -> return xs

--- a/sbvPlugin.cabal
+++ b/sbvPlugin.cabal
@@ -36,7 +36,7 @@ Library
                   , ghc
                   , ghc-prim
                   , containers
-                  , sbv >= 8.8
+                  , sbv >= 8.9
                   , mtl
                   , template-haskell
   Other-modules   : Data.SBV.Plugin.Analyze


### PR DESCRIPTION
Simple bump in the version.  Cabal install fails without it.